### PR TITLE
Delete uncompressed temporaly data after packing them

### DIFF
--- a/install/s6/services/10-mongodb-backup/run
+++ b/install/s6/services/10-mongodb-backup/run
@@ -140,7 +140,7 @@ function uri_parser() {
     # make the dump
     mongodump --out ${TMPDIR}/${TARGET} --host ${DBHOST} --port ${DBPORT} ${USER_STR}${PASS_STR}${DB_STR} ${EXTRA_OPTS}
     cd ${TMPDIR}
-    tar cf ${TARGET}.tar ${TARGET}/*
+    tar cf ${TARGET}.tar ${TARGET}/* && rm -R ${TARGET}
     TARGET=${TARGET}.tar     
 
     # take md5 sum


### PR DESCRIPTION
Current version leaves huge files in /tmp/backups
This PR add cleanup for those files